### PR TITLE
fix: do not do any bpf calls during init

### DIFF
--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -133,7 +133,7 @@ func (ei *ExtInfos) Assign(insns asm.Instructions, section string) {
 
 var nativeEncoderPool = sync.Pool{
 	New: func() any {
-		return newEncoder(kernelEncoderOptions, nil)
+		return newEncoder(kernelEncoderOptions(), nil)
 	},
 }
 

--- a/btf/handle.go
+++ b/btf/handle.go
@@ -30,7 +30,7 @@ func NewHandle(spec *Spec) (*Handle, error) {
 		return nil, fmt.Errorf("can't load %s BTF on %s", spec.byteOrder, internal.NativeEndian)
 	}
 
-	enc := newEncoder(kernelEncoderOptions, newStringTableBuilderFromTable(spec.strings))
+	enc := newEncoder(kernelEncoderOptions(), newStringTableBuilderFromTable(spec.strings))
 
 	for _, typ := range spec.types {
 		_, err := enc.Add(typ)

--- a/btf/marshal.go
+++ b/btf/marshal.go
@@ -17,10 +17,8 @@ type encoderOptions struct {
 }
 
 // kernelEncoderOptions will generate BTF suitable for the current kernel.
-var kernelEncoderOptions encoderOptions
-
-func init() {
-	kernelEncoderOptions = encoderOptions{
+func kernelEncoderOptions() encoderOptions {
+	return encoderOptions{
 		ByteOrder:        internal.NativeEndian,
 		StripFuncLinkage: haveFuncLinkage() != nil,
 	}


### PR DESCRIPTION
## rlimit check
Upstream does these checks inside init function for concurrency safety reasons.

I've done a quick search and it looks like `cillium/ebpf` and `opencontainers/runc` are the only pieces of code trying to call prlimit.

<details>

```
➜  vendor git:(main) ✗ grep -irE "(Prlimit|setrlimit)" .
./golang.org/x/sys/unix/zsysnum_netbsd_amd64.go:        SYS_SETRLIMIT            = 195 // { int|sys||setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_darwin_amd64.go:        SYS_SETRLIMIT                      = 195
./golang.org/x/sys/unix/zsysnum_freebsd_amd64.go:       SYS_SETRLIMIT                = 195 // { int setrlimit(u_int which, struct rlimit *rlp); } setrlimit __setrlimit_args int
./golang.org/x/sys/unix/zsysnum_linux_sparc64.go:       SYS_SETRLIMIT               = 145
./golang.org/x/sys/unix/zsysnum_linux_sparc64.go:       SYS_PRLIMIT64               = 331
./golang.org/x/sys/unix/zsysnum_linux_ppc64le.go:       SYS_SETRLIMIT               = 75
./golang.org/x/sys/unix/zsysnum_linux_ppc64le.go:       SYS_PRLIMIT64               = 325
./golang.org/x/sys/unix/zsysnum_darwin_arm64.go:        SYS_SETRLIMIT                      = 195
./golang.org/x/sys/unix/syscall_linux_loong64.go:       err = Prlimit(0, resource, nil, rlim)
./golang.org/x/sys/unix/zsysnum_dragonfly_amd64.go:     SYS_SETRLIMIT              = 195 // { int setrlimit(u_int which, struct rlimit *rlp); } setrlimit __setrlimit_args int
./golang.org/x/sys/unix/zsysnum_linux_mips64.go:        SYS_SETRLIMIT               = 5155
./golang.org/x/sys/unix/zsysnum_linux_mips64.go:        SYS_PRLIMIT64               = 5297
./golang.org/x/sys/unix/syscall_linux_mipsx.go: err = Prlimit(0, resource, nil, rlim)
./golang.org/x/sys/unix/zsyscall_zos_s390x.go:func Setrlimit(resource int, lim *Rlimit) (err error) {
./golang.org/x/sys/unix/zsyscall_zos_s390x.go:  _, _, e1 := syscall_rawsyscall(SYS_SETRLIMIT, uintptr(resource), uintptr(unsafe.Pointer(lim)), 0)
./golang.org/x/sys/unix/syscall_linux_arm64.go:// Getrlimit prefers the prlimit64 system call. See issue 38604.
./golang.org/x/sys/unix/syscall_linux_arm64.go: err := Prlimit(0, resource, nil, rlim)
./golang.org/x/sys/unix/zsysnum_linux_arm64.go: SYS_SETRLIMIT               = 164
./golang.org/x/sys/unix/zsysnum_linux_arm64.go: SYS_PRLIMIT64               = 261
./golang.org/x/sys/unix/zsysnum_linux_loong64.go:       SYS_PRLIMIT64               = 261
./golang.org/x/sys/unix/zsysnum_linux_s390x.go: SYS_SETRLIMIT               = 75
./golang.org/x/sys/unix/zsysnum_linux_s390x.go: SYS_PRLIMIT64               = 334
./golang.org/x/sys/unix/zsysnum_openbsd_386.go: SYS_SETRLIMIT      = 195 // { int sys_setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_netbsd_arm64.go:        SYS_SETRLIMIT            = 195 // { int|sys||setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_netbsd_arm.go:  SYS_SETRLIMIT            = 195 // { int|sys||setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_linux_arm.go:   SYS_SETRLIMIT                    = 75
./golang.org/x/sys/unix/zsysnum_linux_arm.go:   SYS_PRLIMIT64                    = 369
./golang.org/x/sys/unix/zsysnum_zos_s390x.go:   SYS_SETRLIMIT                       = 0x293
./golang.org/x/sys/unix/zsysnum_freebsd_arm64.go:       SYS_SETRLIMIT                = 195 // { int setrlimit(u_int which, struct rlimit *rlp); } setrlimit __setrlimit_args int
./golang.org/x/sys/unix/syscall_zos_s390x.go://sysnb    Setrlimit(resource int, lim *Rlimit) (err error)
./golang.org/x/sys/unix/zsysnum_openbsd_mips64.go:      SYS_SETRLIMIT      = 195 // { int sys_setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_linux_riscv64.go:       SYS_SETRLIMIT               = 164
./golang.org/x/sys/unix/zsysnum_linux_riscv64.go:       SYS_PRLIMIT64               = 261
./golang.org/x/sys/unix/zsysnum_freebsd_riscv64.go:     SYS_SETRLIMIT                = 195 // { int setrlimit(u_int which, struct rlimit *rlp); } setrlimit __setrlimit_args int
./golang.org/x/sys/unix/zsysnum_linux_amd64.go: SYS_SETRLIMIT               = 160
./golang.org/x/sys/unix/zsysnum_linux_amd64.go: SYS_PRLIMIT64               = 302
./golang.org/x/sys/unix/zsysnum_freebsd_386.go: SYS_SETRLIMIT                = 195 // { int setrlimit(u_int which, struct rlimit *rlp); } setrlimit __setrlimit_args int
./golang.org/x/sys/unix/zsysnum_openbsd_arm64.go:       SYS_SETRLIMIT      = 195 // { int sys_setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_linux_mips64le.go:      SYS_SETRLIMIT               = 5155
./golang.org/x/sys/unix/zsysnum_linux_mips64le.go:      SYS_PRLIMIT64               = 5297
./golang.org/x/sys/unix/syscall_linux.go://go:linkname syscall_prlimit syscall.prlimit
./golang.org/x/sys/unix/syscall_linux.go:func syscall_prlimit(pid, resource int, newlimit, old *syscall.Rlimit) error
./golang.org/x/sys/unix/syscall_linux.go:func Prlimit(pid, resource int, newlimit, old *Rlimit) error {
./golang.org/x/sys/unix/syscall_linux.go:       return syscall_prlimit(pid, resource, (*syscall.Rlimit)(newlimit), (*syscall.Rlimit)(old))
./golang.org/x/sys/unix/zsysnum_linux_386.go:   SYS_SETRLIMIT                    = 75
./golang.org/x/sys/unix/zsysnum_linux_386.go:   SYS_PRLIMIT64                    = 340
./golang.org/x/sys/unix/zsysnum_openbsd_ppc64.go:       SYS_SETRLIMIT      = 195 // { int sys_setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_linux_ppc.go:   SYS_SETRLIMIT                    = 75
./golang.org/x/sys/unix/zsysnum_linux_ppc.go:   SYS_PRLIMIT64                    = 325
./golang.org/x/sys/unix/syscall_linux_386.go:   err = Prlimit(0, resource, nil, rlim)
./golang.org/x/sys/unix/zsysnum_linux_mips.go:  SYS_SETRLIMIT                    = 4075
./golang.org/x/sys/unix/zsysnum_linux_mips.go:  SYS_PRLIMIT64                    = 4338
./golang.org/x/sys/unix/zsysnum_openbsd_amd64.go:       SYS_SETRLIMIT      = 195 // { int sys_setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_linux_mipsle.go:        SYS_SETRLIMIT                    = 4075
./golang.org/x/sys/unix/zsysnum_linux_mipsle.go:        SYS_PRLIMIT64                    = 4338
./golang.org/x/sys/unix/zsysnum_linux_ppc64.go: SYS_SETRLIMIT               = 75
./golang.org/x/sys/unix/zsysnum_linux_ppc64.go: SYS_PRLIMIT64               = 325
./golang.org/x/sys/unix/zsysnum_openbsd_arm.go: SYS_SETRLIMIT      = 195 // { int sys_setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_freebsd_arm.go: SYS_SETRLIMIT                = 195 // { int setrlimit(u_int which, struct rlimit *rlp); } setrlimit __setrlimit_args int
./golang.org/x/sys/unix/zsysnum_netbsd_386.go:  SYS_SETRLIMIT            = 195 // { int|sys||setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/zsysnum_openbsd_riscv64.go:     SYS_SETRLIMIT      = 195 // { int sys_setrlimit(int which, const struct rlimit *rlp); }
./golang.org/x/sys/unix/syscall_unix.go:// Setrlimit sets a resource limit.
./golang.org/x/sys/unix/syscall_unix.go:func Setrlimit(resource int, rlim *Rlimit) error {
./golang.org/x/sys/unix/syscall_unix.go:        return syscall.Setrlimit(resource, (*syscall.Rlimit)(rlim))
./golang.org/x/sys/unix/syscall_linux_arm.go:   err = Prlimit(0, resource, nil, rlim)
./golang.org/x/sys/unix/syscall_linux_ppc.go:   err = Prlimit(0, resource, nil, rlim)
./golang.org/x/tools/internal/imports/zstdlib.go:               "SYS_PRLIMIT64",
./golang.org/x/tools/internal/imports/zstdlib.go:               "SYS_SETRLIMIT",
./golang.org/x/tools/internal/imports/zstdlib.go:               "Setrlimit",
./github.com/cilium/ebpf/internal/unix/types_linux.go:func Prlimit(pid, resource int, new, old *Rlimit) error {
./github.com/cilium/ebpf/internal/unix/types_linux.go:  return linux.Prlimit(pid, resource, new, old)
./github.com/cilium/ebpf/internal/unix/types_other.go:func Prlimit(pid, resource int, new, old *Rlimit) error {
./github.com/cilium/ebpf/rlimit/rlimit.go:      if err := unix.Prlimit(0, unix.RLIMIT_MEMLOCK, nil, &oldLimit); err != nil {
./github.com/cilium/ebpf/rlimit/rlimit.go:      if err := unix.Prlimit(0, unix.RLIMIT_MEMLOCK, &zeroLimit, &oldLimit); err != nil {
./github.com/cilium/ebpf/rlimit/rlimit.go:      if err := unix.Prlimit(0, unix.RLIMIT_MEMLOCK, &oldLimit, nil); err != nil {
./github.com/cilium/ebpf/rlimit/rlimit.go:// invoking prlimit(2) directly with a more reasonable limit if desired.
./github.com/cilium/ebpf/rlimit/rlimit.go:      if err := unix.Prlimit(0, unix.RLIMIT_MEMLOCK, &newLimit, nil); err != nil {
./github.com/opencontainers/runc/libcontainer/process_linux.go: if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
./github.com/opencontainers/runc/libcontainer/process_linux.go:                 if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
./github.com/opencontainers/runc/libcontainer/init_linux.go:func setupRlimits(limits []configs.Rlimit, pid int) error {
./github.com/opencontainers/runc/libcontainer/init_linux.go:            if err := unix.Prlimit(pid, rlimit.Type, &unix.Rlimit{Max: rlimit.Hard, Cur: rlimit.Soft}, nil); err != nil {
./github.com/opencontainers/runc/libcontainer/cgroups/ebpf/ebpf_linux.go:       _ = unix.Setrlimit(unix.RLIMIT_MEMLOCK, memlockLimit)


```
</details>

I do not believe grafana agent spawns any containers so I think we can ignore it.
I made `detectMemcgAccounting` running under lock, so we should be safe

## btf
I think this was just overlooked by the cilium authors
## testing

before
```
strace ./build/grafana-agent-flow run /home/korniltsev/trash/noop.river 2>&1 | grep -iE "(bpf|rlim|btf)"
prlimit64(0, RLIMIT_STACK, NULL, {rlim_cur=8192*1024, rlim_max=RLIM64_INFINITY}) = 0
getrlimit(RLIMIT_NOFILE, {rlim_cur=1024, rlim_max=1024*1024}) = 0
setrlimit(RLIMIT_NOFILE, {rlim_cur=1024*1024, rlim_max=1024*1024}) = 0
bpf(BPF_BTF_LOAD, {btf="\237\353\1\0\30\0\0\0\0\0\0\0\20\0\0\0\20\0\0\0\1\0\0\0\0\0\0\0\0\0\0\1"..., btf_log_buf=NULL, btf_size=41, btf_log_size=0, btf_log_level=0}, 32) = -1 EPERM (Operation not permitted)
prlimit64(0, RLIMIT_MEMLOCK, NULL, {rlim_cur=8218828*1024, rlim_max=8218828*1024}) = 0
prlimit64(0, RLIMIT_MEMLOCK, {rlim_cur=0, rlim_max=8218828*1024}, {rlim_cur=8218828*1024, rlim_max=8218828*1024}) = 0
bpf(BPF_MAP_CREATE, {map_type=BPF_MAP_TYPE_ARRAY, key_size=4, value_size=4, max_entries=1, map_flags=0, inner_map_fd=0, map_name="", map_ifindex=0, btf_fd=0, btf_key_type_id=0, btf_value_type_id=0, btf_vmlinux_value_type_id=0, map_extra=0}, 72) = -1 EPERM (Operation not permitted)
prlimit64(0, RLIMIT_MEMLOCK, {rlim_cur=8218828*1024, rlim_max=8218828*1024}, NULL) = 0

```

after
```
strace ./build/grafana-agent-flow run /home/korniltsev/trash/noop.river 2>&1 | grep -iE "(bpf|rlim|btf)" 
prlimit64(0, RLIMIT_STACK, NULL, {rlim_cur=8192*1024, rlim_max=RLIM64_INFINITY}) = 0
getrlimit(RLIMIT_NOFILE, {rlim_cur=1024, rlim_max=1024*1024}) = 0
setrlimit(RLIMIT_NOFILE, {rlim_cur=1024*1024, rlim_max=1024*1024}) = 0

```

